### PR TITLE
Delete old TrackList before appending them at every restart

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 pip3 -qq install --upgrade yt-dlp
+sed -i '42,$d' /app/aria.conf
 tracker_list=`curl -Ns https://raw.githubusercontent.com/XIU2/TrackersListCollection/master/all.txt | awk '$1' | tr '\n' ',' | cat`
 echo -e "\nmax-concurrent-downloads=4\nbt-tracker=$tracker_list" >> /app/aria.conf
 aria2c --conf-path=/app/aria.conf

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,5 @@
 pip3 -qq install --upgrade yt-dlp
-sed -i '42,$d' /app/aria.conf
+sed -n -i '/max-concurrent-downloads/q;p' /app/aria.conf
 tracker_list=`curl -Ns https://raw.githubusercontent.com/XIU2/TrackersListCollection/master/all.txt | awk '$1' | tr '\n' ',' | cat`
 echo -e "\nmax-concurrent-downloads=4\nbt-tracker=$tracker_list" >> /app/aria.conf
 aria2c --conf-path=/app/aria.conf


### PR DESCRIPTION
Since we are not having the trackers directly in aria.conf and instead appending them at every instance of restart , currently the its appending the trackerlist to aria.conf continuously on every restart which is not ideal . So clearing and changing aria.conf to its original state before appending tracklist again